### PR TITLE
S3 upload improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ K8s handling can be configured using the following OS environment variables:
 | LP4K_CM_UPDATE_FREQ | "30s" | update frequency of ConfigMap and STDOUT if enabled (default), must be valid Go time.Duration string like "30s" or 2m30s"
 | LP4K_CM_PREFIX | "lp4k-cm" | nodeclaim ConfigMap prefix, if KARPENTER_LP4K_CM_OVERRIDE=false or ConfigMap name, if KARPENTER_LP4K_CM_OVERRIDE=true
 | LP4K_CM_OVERRIDE | "false" | determines, if ConfigMap will just use prefix and will be overriden upon every start of lp4k
-| LP4K_NODECLAIM_PRINT | "true" | print nodeclaim information every KARPENTER_CM_UPDATE_FREQ to STDOUT
+| LP4K_NODECLAIM_PRINT | "true" | print nodeclaim information every KARPENTER_CM_UPDATE_FREQ to STDOUT
+| LP4K_TIME_FORMAT | "2006-01-02-15-04-05" | time format for ConfigMap names and S3 object timestamps, must be a valid Go time layout string
 
 \* Note: In mode `LP4K_CM_OVERRIDE=true` **lp4k** will read existing nodeclaim data from ConfigMap specified by LP4K_CM_PREFIX
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ K8s handling can be configured using the following OS environment variables:
 | LP4K_S3_BUCKET | "" (disabled) | S3 bucket name where CSV files will be uploaded. S3 upload is only enabled when this is set
 | LP4K_S3_PREFIX | "karpenter-logs" | S3 key prefix for uploaded files
 | LP4K_S3_REGION | "us-east-1" | AWS region for S3 bucket
+| LP4K_S3_OVERWRITE | "false" | If true, overwrites the same S3 object (using program start time) on each update. If false, creates new timestamped objects on each update
 
 When S3 upload is enabled, **lp4k** will:
 - Upload CSV files with timestamp in the filename: `karpenter-nodeclaims-YYYY-MM-DD-HH-MM-SS.csv`

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -106,10 +105,8 @@ func nodeclaimsConfigMap(ctx context.Context, clientSet *kubernetes.Clientset, n
 		// use unique ConfigMap name and override on every start
 		configmap = configmappref
 	} else {
-		// construct ConfigMap name from time stamp - it probably contains non-DNS characters, so modify accordingly
-		configmap = fmt.Sprintf("%s-%s", configmappref, strings.Replace(time.Now().Format(time.RFC3339), ":", "", -1))
-		configmap, _, _ = strings.Cut(configmap, "+")
-		configmap = strings.Replace(configmap, "T", "-", -1)
+		// construct ConfigMap name from time stamp
+		configmap = fmt.Sprintf("%s-%s", configmappref, s3.GetStartTimestamp())
 	}
 	fmt.Fprintf(os.Stderr, "\nUsing ConfigMap \"%s\" in namespace \"%s\" with updates every %s\n", configmap, namespace, cmupdfreq.String())
 	cm := v1.ConfigMap{

--- a/main.go
+++ b/main.go
@@ -72,8 +72,6 @@ func main() {
 				if err := s3.UploadToS3(nodeclaimmap); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: Failed to upload to S3: %v\n", err)
 				}
-			} else {
-				fmt.Fprintf(os.Stderr, "S3 upload not configured - skipping upload\n")
 			}
 		}
 	} else {

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -25,9 +25,12 @@ const (
 	s3PrefixEnv    = "LP4K_S3_PREFIX"
 	s3RegionEnv    = "LP4K_S3_REGION"
 	s3OverwriteEnv = "LP4K_S3_OVERWRITE"
+	timeFormatEnv  = "LP4K_TIME_FORMAT"
 	// context timeouts
 	configTimeout = 5 * time.Second
 	uploadTimeout = 30 * time.Second
+	// default time format
+	defaultTimeFormat = "2006-01-02-15-04-05"
 )
 
 var s3Bucket, s3Prefix, s3Region string
@@ -36,14 +39,16 @@ var s3Client *s3.Client
 var once sync.Once
 var clientErr error
 var startTimestamp string
+var timeFormat string
 
 // Initialize S3 configuration from environment variables
 func init() {
+	timeFormat = getEnvOrDefault(timeFormatEnv, defaultTimeFormat)
 	s3Bucket = os.Getenv(s3BucketEnv)
 	s3Prefix = getEnvOrDefault(s3PrefixEnv, "karpenter-logs")
 	s3Region = getEnvOrDefault(s3RegionEnv, "us-east-1")
 	s3Overwrite = getEnvBoolOrDefault(s3OverwriteEnv, false)
-	startTimestamp = time.Now().Format("2006-01-02-15-04-05")
+	startTimestamp = time.Now().Format(timeFormat)
 	// S3 is enabled only if bucket is specified
 	s3Enabled = s3Bucket != ""
 	if s3Enabled {
@@ -123,7 +128,7 @@ func UploadToS3(nodeclaimmap *map[string]lp4k.Nodeclaimstruct) error {
 		s3Key = fmt.Sprintf("%s/karpenter-nodeclaims-%s.csv", strings.TrimSuffix(s3Prefix, "/"), startTimestamp)
 	} else {
 		// Use current timestamp for timestamped mode (new key on each update)
-		timestamp := time.Now().Format("2006-01-02-15-04-05")
+		timestamp := time.Now().Format(timeFormat)
 		s3Key = fmt.Sprintf("%s/karpenter-nodeclaims-%s.csv", strings.TrimSuffix(s3Prefix, "/"), timestamp)
 	}
 	// Upload to S3

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,20 +23,24 @@ const (
 	s3BucketEnv = "LP4K_S3_BUCKET"
 	s3PrefixEnv = "LP4K_S3_PREFIX"
 	s3RegionEnv = "LP4K_S3_REGION"
+	// context timeouts
+	configTimeout = 5 * time.Second
+	uploadTimeout = 30 * time.Second
 )
 
 var s3Bucket, s3Prefix, s3Region string
 var s3Enabled bool
+var s3Client *s3.Client
+var once sync.Once
+var clientErr error
 
 // Initialize S3 configuration from environment variables
 func init() {
 	s3Bucket = os.Getenv(s3BucketEnv)
 	s3Prefix = getEnvOrDefault(s3PrefixEnv, "karpenter-logs")
 	s3Region = getEnvOrDefault(s3RegionEnv, "us-east-1")
-
 	// S3 is enabled only if bucket is specified
 	s3Enabled = s3Bucket != ""
-
 	if s3Enabled {
 		fmt.Fprintf(os.Stderr, "S3 upload enabled: bucket=%s, prefix=%s, region=%s\n", s3Bucket, s3Prefix, s3Region)
 	}
@@ -48,47 +53,65 @@ func getEnvOrDefault(key, defaultVal string) string {
 	return defaultVal
 }
 
+// getS3Client returns a cached S3 client, creating it once on first call
+// Uses sync.Once to ensure thread-safe singleton pattern
+func getS3Client(ctx context.Context) (*s3.Client, error) {
+	once.Do(func() {
+		// Create context with timeout for config loading
+		cfgCtx, cancel := context.WithTimeout(ctx, configTimeout)
+		defer cancel()
+		cfg, err := config.LoadDefaultConfig(cfgCtx, config.WithRegion(s3Region))
+		if err != nil {
+			clientErr = fmt.Errorf("unable to load AWS SDK config: %w", err)
+			return
+		}
+		s3Client = s3.NewFromConfig(cfg)
+	})
+	return s3Client, clientErr
+}
+
 // IsEnabled returns whether S3 upload is configured
 func IsEnabled() bool {
 	return s3Enabled
 }
 
-// UploadToS3 uploads the nodeclaim CSV data to S3
+// UploadToS3 uploads the nodeclaim CSV data to S3 with timeout and context cancellation support
+// The S3 client is cached and reused across multiple calls for efficiency
 func UploadToS3(nodeclaimmap *map[string]lp4k.Nodeclaimstruct) error {
 	if !s3Enabled {
 		return nil
 	}
-
-	ctx := context.Background()
-
-	// Load AWS configuration
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(s3Region))
+	// Create context with upload timeout
+	uploadCtx, cancel := context.WithTimeout(context.Background(), uploadTimeout)
+	defer cancel()
+	// Get cached S3 client
+	client, err := getS3Client(uploadCtx)
 	if err != nil {
-		return fmt.Errorf("unable to load AWS SDK config: %w", err)
+		return err
 	}
-
-	// Create S3 client
-	client := s3.NewFromConfig(cfg)
-
 	// Convert nodeclaimmap to CSV
 	csvData := lp4k.ConvertToCSV(nodeclaimmap)
-
 	// Generate S3 key with timestamp
 	timestamp := time.Now().Format("2006-01-02-15-04-05")
 	s3Key := fmt.Sprintf("%s/karpenter-nodeclaims-%s.csv", strings.TrimSuffix(s3Prefix, "/"), timestamp)
-
 	// Upload to S3
-	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+	_, err = client.PutObject(uploadCtx, &s3.PutObjectInput{
 		Bucket:      aws.String(s3Bucket),
 		Key:         aws.String(s3Key),
 		Body:        bytes.NewReader([]byte(csvData)),
 		ContentType: aws.String("text/csv"),
 	})
-
+	// Check context state for better error messages
 	if err != nil {
-		return fmt.Errorf("failed to upload to S3: %w", err)
+		switch uploadCtx.Err() {
+		case context.Canceled:
+			return fmt.Errorf("S3 upload cancelled: %w", err)
+		case context.DeadlineExceeded:
+			return fmt.Errorf("S3 upload timeout exceeded: %w", err)
+		default:
+			return fmt.Errorf("failed to upload to S3: %w", err)
+		}
 	}
-
 	fmt.Fprintf(os.Stderr, "Successfully uploaded to s3://%s/%s\n", s3Bucket, s3Key)
 	return nil
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -20,29 +21,37 @@ import (
 
 const (
 	// environment variables
-	s3BucketEnv = "LP4K_S3_BUCKET"
-	s3PrefixEnv = "LP4K_S3_PREFIX"
-	s3RegionEnv = "LP4K_S3_REGION"
+	s3BucketEnv    = "LP4K_S3_BUCKET"
+	s3PrefixEnv    = "LP4K_S3_PREFIX"
+	s3RegionEnv    = "LP4K_S3_REGION"
+	s3OverwriteEnv = "LP4K_S3_OVERWRITE"
 	// context timeouts
 	configTimeout = 5 * time.Second
 	uploadTimeout = 30 * time.Second
 )
 
 var s3Bucket, s3Prefix, s3Region string
-var s3Enabled bool
+var s3Enabled, s3Overwrite bool
 var s3Client *s3.Client
 var once sync.Once
 var clientErr error
+var startTimestamp string
 
 // Initialize S3 configuration from environment variables
 func init() {
 	s3Bucket = os.Getenv(s3BucketEnv)
 	s3Prefix = getEnvOrDefault(s3PrefixEnv, "karpenter-logs")
 	s3Region = getEnvOrDefault(s3RegionEnv, "us-east-1")
+	s3Overwrite = getEnvBoolOrDefault(s3OverwriteEnv, false)
+	startTimestamp = time.Now().Format("2006-01-02-15-04-05")
 	// S3 is enabled only if bucket is specified
 	s3Enabled = s3Bucket != ""
 	if s3Enabled {
-		fmt.Fprintf(os.Stderr, "S3 upload enabled: bucket=%s, prefix=%s, region=%s\n", s3Bucket, s3Prefix, s3Region)
+		mode := "timestamped mode"
+		if s3Overwrite {
+			mode = "overwrite mode"
+		}
+		fmt.Fprintf(os.Stderr, "S3 upload enabled: bucket=%s, prefix=%s, region=%s (%s)\n", s3Bucket, s3Prefix, s3Region, mode)
 	}
 }
 
@@ -51,6 +60,15 @@ func getEnvOrDefault(key, defaultVal string) string {
 		return val
 	}
 	return defaultVal
+}
+
+func getEnvBoolOrDefault(key string, defaultVal bool) bool {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultVal
+	}
+	b, _ := strconv.ParseBool(val)
+	return b
 }
 
 // getS3Client returns a cached S3 client, creating it once on first call
@@ -75,8 +93,15 @@ func IsEnabled() bool {
 	return s3Enabled
 }
 
+// GetStartTimestamp returns the program start timestamp in format YYYY-MM-DD-HH-MM-SS
+func GetStartTimestamp() string {
+	return startTimestamp
+}
+
 // UploadToS3 uploads the nodeclaim CSV data to S3 with timeout and context cancellation support
 // The S3 client is cached and reused across multiple calls for efficiency
+// If LP4K_S3_OVERWRITE=true, the same object is overwritten on each call
+// Otherwise, a new timestamped object is created on each call
 func UploadToS3(nodeclaimmap *map[string]lp4k.Nodeclaimstruct) error {
 	if !s3Enabled {
 		return nil
@@ -91,9 +116,16 @@ func UploadToS3(nodeclaimmap *map[string]lp4k.Nodeclaimstruct) error {
 	}
 	// Convert nodeclaimmap to CSV
 	csvData := lp4k.ConvertToCSV(nodeclaimmap)
-	// Generate S3 key with timestamp
-	timestamp := time.Now().Format("2006-01-02-15-04-05")
-	s3Key := fmt.Sprintf("%s/karpenter-nodeclaims-%s.csv", strings.TrimSuffix(s3Prefix, "/"), timestamp)
+	// Generate S3 key
+	var s3Key string
+	if s3Overwrite {
+		// Use start timestamp for overwrite mode (same key on each update)
+		s3Key = fmt.Sprintf("%s/karpenter-nodeclaims-%s.csv", strings.TrimSuffix(s3Prefix, "/"), startTimestamp)
+	} else {
+		// Use current timestamp for timestamped mode (new key on each update)
+		timestamp := time.Now().Format("2006-01-02-15-04-05")
+		s3Key = fmt.Sprintf("%s/karpenter-nodeclaims-%s.csv", strings.TrimSuffix(s3Prefix, "/"), timestamp)
+	}
 	// Upload to S3
 	_, err = client.PutObject(uploadCtx, &s3.PutObjectInput{
 		Bucket:      aws.String(s3Bucket),

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -44,6 +44,13 @@ var timeFormat string
 // Initialize S3 configuration from environment variables
 func init() {
 	timeFormat = getEnvOrDefault(timeFormatEnv, defaultTimeFormat)
+	// Validate time format by attempting to parse a formatted time
+	testTime := time.Now()
+	formatted := testTime.Format(timeFormat)
+	if _, err := time.Parse(timeFormat, formatted); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Invalid LP4K_TIME_FORMAT \"%s\", falling back to default \"%s\"\n", timeFormat, defaultTimeFormat)
+		timeFormat = defaultTimeFormat
+	}
 	s3Bucket = os.Getenv(s3BucketEnv)
 	s3Prefix = getEnvOrDefault(s3PrefixEnv, "karpenter-logs")
 	s3Region = getEnvOrDefault(s3RegionEnv, "us-east-1")


### PR DESCRIPTION
*Issue #3

*Description of changes:*
It is possible now to have just one S3 key during one "session" (aka. invocation of lp4k) and overwrite every `LP4K_CM_UPDATE_FREQ` as an additional option `LP4K_S3_OVERWRITE` , which defaults to false.

In addition `LP4K_TIME_FORMAT` let you specify your own time format for ConfigMap and S3 key name (including validation).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
