### PR TITLE
feat: auto-detect Grafana/Loki JSON array input format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 lp4k
 lp4kcm
 karpenter-*.txt
+CLAUDE.md
 .DS_Store
 bin/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 
 It allows using either STDIN (for example for piping live Karpenter controller logs) or multiple Karpenter log files as input and will print CSV style formatted output of nodeclaim data ordered by createdtime to STDOUT, so one can easily redirect it into a file and analyse with tools like [Amazon QuickSight](https://docs.aws.amazon.com/quicksight/latest/user/welcome.html) or Microsoft Excel.
 
+**lp4k** supports two input formats which are automatically detected:
+1. **Plain text** — raw Karpenter controller log output (one JSON log line per line)
+2. **JSON array** — Grafana/Loki log export format (a JSON array of objects, each requiring a `"line"` field with the raw Karpenter log line and a `"date"` field for chronological sorting)
+
+No flags are needed — the format is detected automatically for both file arguments and STDIN input.
+
 If neither STDIN nor log files are used as input, **lp4k** will attach to a running K8s/EKS cluster and parses Karpenter logs (streamed logs, similar to *kubectl logs -f* using LP4K_KARPENTER_NAMESPACE and LP4K_KARPENTER_LABEL) and creates a ConfigMap *lp4k-cm-\<date\>* in same namespace, which gets updated every LP4K_CM_UPDATE_FREQ.
 
 K8s handling can be configured using the following OS environment variables:
@@ -113,11 +119,23 @@ or
 ```bash
 ./bin/lp4k <Karpenter log output file 1> [... <Karpenter log output file n>]
 ```
-or
+or with Grafana/Loki JSON export files:
 ```bash
-kubectl logs -n kube-system <Karpenter leader pod> [-f] | ./lp4k
+./bin/lp4k grafana-export.json
 ```
-or for attaching to K8s/EKS cluster in current KUBECONFIG context
+or mix plain text and JSON files in a single invocation:
+```bash
+./bin/lp4k karpenter-logs.txt grafana-export.json
+```
+or pipe from kubectl:
+```bash
+kubectl logs -n kube-system <Karpenter leader pod> [-f] | ./bin/lp4k
+```
+or pipe a Grafana/Loki JSON export via STDIN:
+```bash
+cat grafana-export.json | ./bin/lp4k
+```
+or for attaching to K8s/EKS cluster in current KUBECONFIG context:
 ```bash
 ./bin/lp4k
 ```

--- a/grafana-export.json
+++ b/grafana-export.json
@@ -1,0 +1,222 @@
+[
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T18:54:32.448Z\",\"logger\":\"controller\",\"message\":\"deleted nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"nodeclaim.lifecycle\",\"controllerGroup\":\"karpenter.sh\",\"controllerKind\":\"NodeClaim\",\"NodeClaim\":{\"name\":\"spot-c6pmd\"},\"namespace\":\"\",\"name\":\"spot-c6pmd\",\"reconcileID\":\"be65a322-36e2-4c1e-a663-526554f46500\",\"provider-id\":\"aws:///eu-central-1a/i-03b853ed22694ea1e\",\"Node\":{\"name\":\"ip-10-250-108-164.eu-central-1.compute.internal\"}}",
+		"timestamp": "1781808872448184729",
+		"date": "2026-06-18T18:54:32.448Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T18:53:38.954Z\",\"logger\":\"controller\",\"message\":\"tainted node\",\"commit\":\"e7e1327\",\"controller\":\"node.termination\",\"controllerGroup\":\"\",\"controllerKind\":\"Node\",\"Node\":{\"name\":\"ip-10-250-108-164.eu-central-1.compute.internal\"},\"namespace\":\"\",\"name\":\"ip-10-250-108-164.eu-central-1.compute.internal\",\"reconcileID\":\"b8d65752-d79d-495d-a4ea-529f2459aa8f\",\"NodeClaim\":{\"name\":\"spot-c6pmd\"},\"taint.Key\":\"karpenter.sh/disrupted\",\"taint.Value\":\"\",\"taint.Effect\":\"NoSchedule\"}",
+		"timestamp": "1781808818954971336",
+		"date": "2026-06-18T18:53:38.954Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T18:53:38.910Z\",\"logger\":\"controller\",\"message\":\"annotated nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"nodeclaim.lifecycle\",\"controllerGroup\":\"karpenter.sh\",\"controllerKind\":\"NodeClaim\",\"NodeClaim\":{\"name\":\"spot-c6pmd\"},\"namespace\":\"\",\"name\":\"spot-c6pmd\",\"reconcileID\":\"9819a96d-1e41-4aa4-9395-f3d468c621a6\",\"provider-id\":\"aws:///eu-central-1a/i-03b853ed22694ea1e\",\"Node\":{\"name\":\"ip-10-250-108-164.eu-central-1.compute.internal\"},\"karpenter.sh/nodeclaim-termination-timestamp\":\"2026-06-25T18:53:38Z\"}",
+		"timestamp": "1781808818910409342",
+		"date": "2026-06-18T18:53:38.910Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T18:53:38.600Z\",\"logger\":\"controller\",\"message\":\"initialized nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"nodeclaim.lifecycle\",\"controllerGroup\":\"karpenter.sh\",\"controllerKind\":\"NodeClaim\",\"NodeClaim\":{\"name\":\"spot-5lbr8\"},\"namespace\":\"\",\"name\":\"spot-5lbr8\",\"reconcileID\":\"1622dbad-c3d2-4424-9fc1-205fe23902dd\",\"provider-id\":\"aws:///eu-central-1a/i-0aa2c06e631b912e9\",\"Node\":{\"name\":\"ip-10-250-108-46.eu-central-1.compute.internal\"},\"allocatable\":{\"cpu\":\"7910m\",\"ephemeral-storage\":\"95500736762\",\"hugepages-1Gi\":\"0\",\"hugepages-2Mi\":\"0\",\"memory\":\"15218236Ki\",\"pods\":\"44\"}}",
+		"timestamp": "1781808818609970093",
+		"date": "2026-06-18T18:53:38.609Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T18:53:15.472Z\",\"logger\":\"controller\",\"message\":\"registered nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"nodeclaim.lifecycle\",\"controllerGroup\":\"karpenter.sh\",\"controllerKind\":\"NodeClaim\",\"NodeClaim\":{\"name\":\"spot-5lbr8\"},\"namespace\":\"\",\"name\":\"spot-5lbr8\",\"reconcileID\":\"70f281d9-1907-47b4-8dde-43d5706b3ec2\",\"provider-id\":\"aws:///eu-central-1a/i-0aa2c06e631b912e9\",\"Node\":{\"name\":\"ip-10-250-108-46.eu-central-1.compute.internal\"}}",
+		"timestamp": "1781808795472714488",
+		"date": "2026-06-18T18:53:15.472Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T18:53:06.235Z\",\"logger\":\"controller\",\"message\":\"launched nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"nodeclaim.lifecycle\",\"controllerGroup\":\"karpenter.sh\",\"controllerKind\":\"NodeClaim\",\"NodeClaim\":{\"name\":\"spot-5lbr8\"},\"namespace\":\"\",\"name\":\"spot-5lbr8\",\"reconcileID\":\"db1a54be-e3ca-4500-ba66-f45a00e07058\",\"provider-id\":\"aws:///eu-central-1a/i-0aa2c06e631b912e9\",\"instance-type\":\"c7i.2xlarge\",\"zone\":\"eu-central-1a\",\"capacity-type\":\"spot\",\"allocatable\":{\"cpu\":\"7910m\",\"ephemeral-storage\":\"89Gi\",\"memory\":\"15218216Ki\",\"pods\":\"44\",\"vpc.amazonaws.com/pod-eni\":\"38\"}}",
+		"timestamp": "1781808786235585504",
+		"date": "2026-06-18T18:53:06.235Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T18:53:03.833Z\",\"logger\":\"controller\",\"message\":\"created nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"disruption\",\"namespace\":\"\",\"name\":\"\",\"reconcileID\":\"26a5a4eb-4a02-4aeb-8457-f359979ee2ac\",\"NodePool\":{\"name\":\"spot\"},\"NodeClaim\":{\"name\":\"spot-5lbr8\"},\"requests\":{\"cpu\":\"4665m\",\"ephemeral-storage\":\"1650Mi\",\"memory\":\"8931087232\",\"pods\":\"14\"},\"instance-types\":\"c5.2xlarge, c5.4xlarge, c5a.2xlarge, c5ad.2xlarge, c5d.2xlarge and 10 other(s)\"}",
+		"timestamp": "1781808783833306740",
+		"date": "2026-06-18T18:53:03.833Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T18:00:02.156Z\",\"logger\":\"controller\",\"message\":\"initialized nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"nodeclaim.lifecycle\",\"controllerGroup\":\"karpenter.sh\",\"controllerKind\":\"NodeClaim\",\"NodeClaim\":{\"name\":\"spot-c6pmd\"},\"namespace\":\"\",\"name\":\"spot-c6pmd\",\"reconcileID\":\"3e462eac-7fdf-4bad-a79e-5bd9356a891b\",\"provider-id\":\"aws:///eu-central-1a/i-03b853ed22694ea1e\",\"Node\":{\"name\":\"ip-10-250-108-164.eu-central-1.compute.internal\"},\"allocatable\":{\"cpu\":\"7910m\",\"ephemeral-storage\":\"95500736762\",\"hugepages-1Gi\":\"0\",\"hugepages-2Mi\":\"0\",\"memory\":\"15130168Ki\",\"pods\":\"44\"}}",
+		"timestamp": "1781805602156842829",
+		"date": "2026-06-18T18:00:02.156Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T17:59:35.422Z\",\"logger\":\"controller\",\"message\":\"registered nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"nodeclaim.lifecycle\",\"controllerGroup\":\"karpenter.sh\",\"controllerKind\":\"NodeClaim\",\"NodeClaim\":{\"name\":\"spot-c6pmd\"},\"namespace\":\"\",\"name\":\"spot-c6pmd\",\"reconcileID\":\"5a0284b2-7691-4181-a790-a7588bc7ec86\",\"provider-id\":\"aws:///eu-central-1a/i-03b853ed22694ea1e\",\"Node\":{\"name\":\"ip-10-250-108-164.eu-central-1.compute.internal\"}}",
+		"timestamp": "1781805575422140466",
+		"date": "2026-06-18T17:59:35.422Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T17:59:25.233Z\",\"logger\":\"controller\",\"message\":\"launched nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"nodeclaim.lifecycle\",\"controllerGroup\":\"karpenter.sh\",\"controllerKind\":\"NodeClaim\",\"NodeClaim\":{\"name\":\"spot-c6pmd\"},\"namespace\":\"\",\"name\":\"spot-c6pmd\",\"reconcileID\":\"300a8812-befe-44fc-a0e7-313dfbe4aef8\",\"provider-id\":\"aws:///eu-central-1a/i-03b853ed22694ea1e\",\"instance-type\":\"c7a.2xlarge\",\"zone\":\"eu-central-1a\",\"capacity-type\":\"spot\",\"allocatable\":{\"cpu\":\"7910m\",\"ephemeral-storage\":\"89Gi\",\"memory\":\"15130152Ki\",\"pods\":\"44\",\"vpc.amazonaws.com/pod-eni\":\"38\"}}",
+		"timestamp": "1781805565233222249",
+		"date": "2026-06-18T17:59:25.233Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	},
+	{
+		"line": "{\"level\":\"INFO\",\"time\":\"2026-06-18T17:59:21.432Z\",\"logger\":\"controller\",\"message\":\"created nodeclaim\",\"commit\":\"e7e1327\",\"controller\":\"provisioner\",\"namespace\":\"\",\"name\":\"\",\"reconcileID\":\"edac719e-e781-40ba-9e12-ad0265e0e272\",\"NodePool\":{\"name\":\"spot\"},\"NodeClaim\":{\"name\":\"spot-c6pmd\"},\"requests\":{\"cpu\":\"6215m\",\"ephemeral-storage\":\"1950Mi\",\"memory\":\"12833297280\",\"pods\":\"15\"},\"instance-types\":\"c5.2xlarge, c5.4xlarge, c5a.2xlarge, c5a.4xlarge, c5ad.2xlarge and 100 other(s)\"}",
+		"timestamp": "1781805561432685903",
+		"date": "2026-06-18T17:59:21.432Z",
+		"fields": {
+			"app": "karpenter",
+			"container": "controller",
+			"container_image": "public.ecr.aws/karpenter/controller:1.9.0@sha256:30a506c64fbb1d8026cbfd9a1d662be3ab6e33a7999290a104085d78b49a69d7",
+			"detected_level": "info",
+			"job": "pod_logs",
+			"label_app_kubernetes_io_instance": "karpenter",
+			"namespace": "karpenter",
+			"node": "ip-10-250-109-202.eu-central-1.compute.internal",
+			"node_ip": "10.250.109.202",
+			"pod": "karpenter-5ff58bd574-fc5bh",
+			"pod_ip": "100.64.88.251",
+			"service_name": "karpenter",
+			"stream": "stdout"
+		}
+	}
+]

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
 	"log"
@@ -52,14 +51,11 @@ func main() {
 			// collect and parse logs
 			k8s.CollectKarpenterLogs(ctx, clientSet, nodeclaimmap, k8snodenamemap)
 		} else {
-			fmt.Fprintf(os.Stderr, "Attached to STDIN - parsing iput until EOF or Ctrl-C\n")
+			fmt.Fprintf(os.Stderr, "Attached to STDIN - parsing input until EOF or Ctrl-C\n")
 			time.Sleep(1 * time.Second)
 
-			ch := make(chan os.Signal, 1)
-			signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
-
-			// main parsing logic
-			lp4k.BlockingParser(ch, bufio.NewScanner(os.Stdin), nodeclaimmap, k8snodenamemap, filename, 0)
+			signal.Notify(make(chan os.Signal, 1), os.Interrupt, syscall.SIGTERM)
+			lp4k.ParseInput(os.Stdin, nodeclaimmap, k8snodenamemap, filename)
 
 			// STDIN empty or Ctrl-C
 			fmt.Fprintf(os.Stderr, "Finished parsing STDIN\n\n")
@@ -86,8 +82,7 @@ func main() {
 			}
 			defer file.Close()
 
-			// main parsing logic
-			lp4k.NonBlockingParser(bufio.NewScanner(file), nodeclaimmap, k8snodenamemap, filename, 0)
+			lp4k.ParseInput(file, nodeclaimmap, k8snodenamemap, filename)
 
 			fmt.Fprintf(os.Stderr, "Finished parsing input file %s\n\n", filename)
 		}
@@ -102,3 +97,4 @@ func main() {
 		}
 	}
 }
+

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,9 +4,12 @@ package parser
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,7 +29,7 @@ var (
 	disruptingReasonPattern  = regexp.MustCompile(`"time":"(.*)","logger".*"reason":"(.*)","decision":"(.*)","disrupted-node-count":(.*),"replacement-node-count":(.*),"pod-count":(.*),"disrupted-nodes":.*,"NodeClaim":{"name":"(.*)"},"capacity-type"`)
 	disruptingCommandPattern = regexp.MustCompile(`"time":"(.*)","logger".*"command":"(.*)","decision":"(.*)","disrupted-node-count":(.*),"replacement-node-count":(.*),"pod-count":(.*),"disrupted-nodes":.*,"NodeClaim":{"name":"(.*)"},"capacity-type"`)
 	interruptionPattern      = regexp.MustCompile(`"time":"(.*)","logger".*"messageKind":"(.*)","NodeClaim":{"name":"(.*)"},"action"`)
-	annotatedPattern         = regexp.MustCompile(`"time":"(.*)","logger".*"NodeClaim":{"name":"(.*)"},"namespace".*,"(.*)":"(.*)"`)
+	annotatedPattern         = regexp.MustCompile(`"time":"(.*)","logger".*"NodeClaim":{"name":"(.*?)"}.*,"([^"]+)":"([^"]+)"}$`)
 	taintedNCPattern         = regexp.MustCompile(`"time":"(.*)","logger".*"NodeClaim":{"name":"(.*)"},"taint.Key":"(.*)","taint.Value":"(.*)","taint.Effect":"(.*)"`)
 	taintedNodePattern       = regexp.MustCompile(`"time":"(.*)","logger".*"Node":{"name":"(.*)"},"namespace".*,"taint.Key":"(.*)","taint.Value":"(.*)","taint.Effect":"(.*)"`)
 	taintedNodeSimplePattern = regexp.MustCompile(`"time":"(.*)","logger".*"Node":{"name":"(.*)"},"namespace"`)
@@ -107,6 +110,44 @@ func NonBlockingParser(scanner *bufio.Scanner, nodeclaimmap *map[string]Nodeclai
 		ParseKarpenterLogs(scanner.Text(), nodeclaimmap, k8snodenamemap, stdin, inputline)
 	}
 	scannerErr(scanner, stdin)
+}
+
+// wrapper around main parsing logic for JSON array input (e.g. Loki/Grafana exports)
+// each array element must have a "line" field containing the raw Karpenter log line
+// entries are sorted chronologically by "date" field before processing
+func jsonArrayParser(r io.Reader, nodeclaimmap *map[string]Nodeclaimstruct, k8snodenamemap *map[string]string, filename string) {
+	decoder := json.NewDecoder(r)
+
+	// consume opening '['
+	if _, err := decoder.Token(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading JSON array start in %s: %v\n", filename, err)
+		return
+	}
+
+	type jsonEntry struct {
+		Line string `json:"line"`
+		Date string `json:"date"`
+	}
+	var entries []jsonEntry
+	for decoder.More() {
+		var entry jsonEntry
+		if err := decoder.Decode(&entry); err != nil {
+			fmt.Fprintf(os.Stderr, "Error decoding JSON element in %s: %v\n", filename, err)
+			continue
+		}
+		if entry.Line != "" {
+			entries = append(entries, entry)
+		}
+	}
+
+	// sort by date ascending so "created nodeclaim" is processed before later lifecycle events
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Date < entries[j].Date
+	})
+
+	for i, entry := range entries {
+		ParseKarpenterLogs(entry.Line, nodeclaimmap, k8snodenamemap, filename, i+1)
+	}
 }
 
 // main parsing logic

--- a/parser/util.go
+++ b/parser/util.go
@@ -3,9 +3,11 @@
 package parser
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"sort"
@@ -111,4 +113,22 @@ func ConvertResult(nodeclaimmap *map[string]Nodeclaimstruct) map[string]string {
 		}
 	}
 	return keyvalueMap
+}
+
+// ParseInput detects the input format and parses it with the appropriate parser.
+// Works with any io.Reader including os.Stdin.
+func ParseInput(r io.Reader, nodeclaimmap *map[string]Nodeclaimstruct, k8snodenamemap *map[string]string, filename string) {
+	br := bufio.NewReader(r)
+	peek, err := br.Peek(1)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", filename, err)
+		return
+	}
+
+	if peek[0] == '[' {
+		fmt.Fprintf(os.Stderr, "Detected JSON array format for %s\n", filename)
+		jsonArrayParser(br, nodeclaimmap, k8snodenamemap, filename)
+	} else {
+		NonBlockingParser(bufio.NewScanner(br), nodeclaimmap, k8snodenamemap, filename, 0)
+	}
 }


### PR DESCRIPTION
## Summary
- Auto-detect Grafana/Loki JSON array format for input files and STDIN (no flags needed)
- Each JSON array element requires a `"line"` field (raw Karpenter log) and a `"date"` field (for chronological sorting)
- Entries are sorted chronologically before parsing, so reverse-ordered exports (as Grafana/Loki produces) work correctly
- Fix `annotatedPattern` regex to handle the `node.health` controller variant introduced in Karpenter v1.2.0
- Add `grafana-export.json` sample file demonstrating the JSON format with a full nodeclaim lifecycle

## Test plan
- [x] `./bin/lp4k sample-input.txt` — plain text file input
- [x] `./bin/lp4k grafana-export.json` — JSON array file input
- [x] `./bin/lp4k sample-input.txt grafana-export.json` — mixed file types
- [x] `cat sample-input.txt | ./bin/lp4k` — plain text via STDIN
- [x] `cat grafana-export.json | ./bin/lp4k` — JSON array via STDIN
- [x] Output piped to awk/grep works as before
- [x] Empty input handled gracefully
- [x] Cross-compilation for linux/amd64 and linux/arm64
- [x] `lp4kcm` tool still builds