### PR TITLE
fix: lp4kcm doesn't parse -kubeconfig arg

### DIFF
--- a/tools/lp4kcm/main.go
+++ b/tools/lp4kcm/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	ctx, clientSet := k8s.ConnectToK8s(kubeconfig)
 
-	for _, arg := range os.Args[1:] {
+	for _, arg := range flag.Args() {
 		cmname = arg
 
 		fmt.Fprintf(os.Stderr, "\nParsing ConfigMap %s\n", cmname)


### PR DESCRIPTION
## Summary
- Use `flag.Args()` instead of `os.Args[1:]` when iterating configmap names, so that flags like `-kubeconfig` are correctly consumed by `flag.Parse()` and not treated as positional arguments.

Closes #18

## Test plan
- [x] `./bin/lp4kcm -kubeconfig=$HOME/.kube/config lp4k-cm-...` correctly reads the specified configmap without trying to parse the flag as a CM name
- [x] `./bin/lp4kcm -help` shows the kubeconfig flag