### PR TITLE
feat: allow Kubernetes context to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ No flags are needed — the format is detected automatically for both file argum
 
 | Flag | Default | Description |
 |---|---|---|
-| `--start` | (none) | Only parse log lines at or after this timestamp (ISO 8601, e.g. `2026-06-18T12:00`) |
-| `--end` | (none) | Only parse log lines at or before this timestamp (ISO 8601, e.g. `2026-06-18T14:00`) |
+| `--start` | (none) | Filter: only parse log lines at or after this ISO 8601 timestamp |
+| `--end` | (none) | Filter: only parse log lines at or before this ISO 8601 timestamp |
+| `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file (env: `KUBECONFIG`) |
+| `--context` | (none) | Kubernetes context to use (env: `LP4K_K8S_CONTEXT`) |
 
 ```bash
 # Parse only events between 12:00 and 14:00
@@ -57,6 +59,7 @@ K8s handling can be configured using the following OS environment variables:
 
 | Environment variable      | Default value     | Description
 | ------------- | ------------- | ------------- |
+| LP4K_K8S_CONTEXT | "" (current-context) | Kubernetes context to use from kubeconfig (useful with multiple clusters or tools like [kubie](https://github.com/kubie-org/kubie))
 | LP4K_KARPENTER_NAMESPACE | "kube-system" | K8s namespace where Karpenter controller is running
 | LP4K_KARPENTER_LABEL | "app.kubernetes.io/name=karpenter" | Karpenter controller K8s pod labels
 | LP4K_CM_UPDATE_FREQ | "30s" | update frequency of ConfigMap and STDOUT if enabled (default), must be valid Go time.Duration string like "30s" or 2m30s"
@@ -184,6 +187,21 @@ Binaries `lp4kcm`, `lp4kchain`, and `lp4kstats` for your OS and platform are bui
 Then run it like:
 ```bash
 ./bin/lp4kcm <lp4k ConfigMap name 1> [... <lp4k ConfigMap name n>]
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--kubeconfig` | `~/.kube/config` | Path to kubeconfig file (env: `KUBECONFIG`) |
+| `--context` | (none) | Kubernetes context to use (env: `LP4K_K8S_CONTEXT`) |
+
+```bash
+# Read ConfigMap from a specific context
+./bin/lp4kcm --context=my-cluster lp4k-cm-2026-06-22-07-54-36
+
+# Or use the environment variable
+LP4K_K8S_CONTEXT=my-cluster ./bin/lp4kcm lp4k-cm-2026-06-22-07-54-36
 ```
 
 ## Analyse LogParserForKarpenter output

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -68,8 +68,13 @@ func getEnvBool(key string, defaultVal bool) bool {
 	return b
 }
 
-func ConnectToK8s(kubeconfig *string) (context.Context, *kubernetes.Clientset) {
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+func ConnectToK8s(kubeconfig *string, k8sContext string) (context.Context, *kubernetes.Clientset) {
+	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: *kubeconfig}
+	overrides := &clientcmd.ConfigOverrides{}
+	if k8sContext != "" {
+		overrides.CurrentContext = k8sContext
+	}
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to build config from flags - %s\n", err.Error())
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -28,12 +28,16 @@ func main() {
 
 	startTime := flag.String("start", "", "filter: only parse log lines at or after this timestamp (ISO 8601, e.g. 2026-06-18T12:00)")
 	endTime := flag.String("end", "", "filter: only parse log lines at or before this timestamp (ISO 8601, e.g. 2026-06-18T14:00)")
+	contextDefault := os.Getenv("LP4K_K8S_CONTEXT")
+	k8sContext := flag.String("context", contextDefault, "Kubernetes context to use (overrides current-context, env: LP4K_K8S_CONTEXT)")
 	var kubeconfig *string
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	kubeconfigDefault := os.Getenv("KUBECONFIG")
+	if kubeconfigDefault == "" {
+		if home := homedir.HomeDir(); home != "" {
+			kubeconfigDefault = filepath.Join(home, ".kube", "config")
+		}
 	}
+	kubeconfig = flag.String("kubeconfig", kubeconfigDefault, "(optional) absolute path to the kubeconfig file (env: KUBECONFIG)")
 	flag.Parse()
 
 	// Set time range filter
@@ -53,7 +57,7 @@ func main() {
 		if termutil.Isatty(os.Stdin.Fd()) {
 			fmt.Fprintf(os.Stderr, "Nothing on STDIN - trying to connect to kube-apiserver\n\n")
 
-			ctx, clientSet := k8s.ConnectToK8s(kubeconfig)
+			ctx, clientSet := k8s.ConnectToK8s(kubeconfig, *k8sContext)
 
 			// collect and parse logs
 			k8s.CollectKarpenterLogs(ctx, clientSet, nodeclaimmap, k8snodenamemap, reconcileIDmap)

--- a/tools/lp4kcm/main.go
+++ b/tools/lp4kcm/main.go
@@ -28,14 +28,18 @@ func main() {
 
 	// parse the .kubeconfig file
 	var kubeconfig *string
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	kubeconfigDefault := os.Getenv("KUBECONFIG")
+	if kubeconfigDefault == "" {
+		if home := homedir.HomeDir(); home != "" {
+			kubeconfigDefault = filepath.Join(home, ".kube", "config")
+		}
 	}
+	kubeconfig = flag.String("kubeconfig", kubeconfigDefault, "(optional) absolute path to the kubeconfig file (env: KUBECONFIG)")
+	contextDefault := os.Getenv("LP4K_K8S_CONTEXT")
+	k8sContext := flag.String("context", contextDefault, "Kubernetes context to use (overrides current-context, env: LP4K_K8S_CONTEXT)")
 	flag.Parse()
 
-	ctx, clientSet := k8s.ConnectToK8s(kubeconfig)
+	ctx, clientSet := k8s.ConnectToK8s(kubeconfig, *k8sContext)
 
 	for _, arg := range flag.Args() {
 		cmname = arg


### PR DESCRIPTION
## Summary
- Adds `-context` flag to `lp4k` and `lp4kcm` for selecting a specific Kubernetes context from the kubeconfig
- Falls back to `LP4K_K8S_CONTEXT` environment variable (compatible with tools like kubie that set `KUBECONFIG` per-context)
- Flag takes precedence over env var; if neither is set, uses the current-context from kubeconfig as before

Closes #17

## Test plan
- [x] `./bin/lp4kcm -context=karpenter-demo lp4k-cm-...` connects to the correct cluster
- [x] `LP4K_K8S_CONTEXT=karpenter-demo ./bin/lp4kcm lp4k-cm-...` works via env var
- [x] Without flag or env var, falls back to default context (verified it hits a different cluster)
- [x] `-context` flag combined with `-kubeconfig` works correctly